### PR TITLE
fix: correct faled→failed typo in error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ fn handle_cli() -> EmptyResult {
         }
         Commands::Execute { seed } => {
             let fuzzer = Fuzzer::new(ZiggyConfig::new(config))
-                .context("Creating a new fuzzer instance faled")?;
+                .context("Creating a new fuzzer instance failed")?;
             fuzzer.execute_harness(ExecuteOneInput(seed))
         }
         Commands::HarnessCover => {


### PR DESCRIPTION
## Summary

Correct spelling mistake in `Fuzzer::new` error context message.

**Before:** `Creating a new fuzzer instance faled`
**After:** `Creating a new fuzzer instance failed`

---

*Submitted with [Jah-yee](https://github.com/Jah-yee) (PR bot).*